### PR TITLE
fix(*) Correct env variable name in the example daemonset.

### DIFF
--- a/deploy/20-daemonset.yaml
+++ b/deploy/20-daemonset.yaml
@@ -20,7 +20,7 @@ spec:
         image: spagiari/k8s-spot-drain:latest
         imagePullPolicy: Always
         env:
-        - name: NODE_NAME
+        - name: MY_NODE_NAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName


### PR DESCRIPTION
The script itself uses MY_NODE_NAME environment variable to get node name