### PR TITLE
feat(*) Changing kubectl installation approach

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,12 +24,12 @@ jobs:
     <<: *defaults
     steps:
        - checkout
-       - run: docker build -t spagiari/k8s-spot-drain:build .
+       - run: docker build -t vivareal/k8s-spot-drain:build .
        - run:
           name: Docker save
           command: |
             mkdir -p docker-cache
-            docker save -o docker-cache/k8s-spot-drain-build.tar spagiari/k8s-spot-drain:build
+            docker save -o docker-cache/k8s-spot-drain-build.tar vivareal/k8s-spot-drain:build
        - save_cache:
           key: k8s-spot-drain-{{ .Environment.CIRCLE_SHA1 }}
           paths:
@@ -47,10 +47,10 @@ jobs:
           name: Load and tag image
           command: |
             docker load < docker-cache/k8s-spot-drain-build.tar
-            docker tag spagiari/k8s-spot-drain:build spagiari/k8s-spot-drain:master
+            docker tag vivareal/k8s-spot-drain:build vivareal/k8s-spot-drain:master
        - run:
           name: Publish Image
-          command: docker push spagiari/k8s-spot-drain:master
+          command: docker push vivareal/k8s-spot-drain:master
 
   publish_tag:
     <<: *defaults
@@ -66,8 +66,8 @@ jobs:
        - run:
           name: Tag and publish image
           command: |
-            docker tag spagiari/k8s-spot-drain:build spagiari/k8s-spot-drain:${CIRCLE_TAG}
-            docker push spagiari/k8s-spot-drain:${CIRCLE_TAG}
+            docker tag vivareal/k8s-spot-drain:build vivareal/k8s-spot-drain:${CIRCLE_TAG}
+            docker push vivareal/k8s-spot-drain:${CIRCLE_TAG}
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ defaults: &defaults
   machine:
     image: circleci/classic:latest
   environment:
-    KUBE_VERSION: 1.11.0
+    KUBE_VERSION: 1.17.0
 
 jobs:
   test_kubefiles:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,11 @@
 FROM alpine:latest
 
-ENV KUBECTL_VERSION=v1.10.8
-
 RUN mkdir -p /app
 WORKDIR /app
 RUN apk -Uuv add curl ca-certificates bash
 RUN apk --purge -v del py-pip && \
     update-ca-certificates && \
 	rm /var/cache/apk/*
-RUN wget -O kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl && chmod +x ./kubectl
 
 ADD run.sh /app/run.sh
 

--- a/deploy/20-daemonset.yaml
+++ b/deploy/20-daemonset.yaml
@@ -26,3 +26,5 @@ spec:
               fieldPath: spec.nodeName
         - name: DEBUG
           value: "false"
+        - name: KUBECTL_VERSION
+          value: "1.17.11"

--- a/run.sh
+++ b/run.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 trap "exit 0" SIGINT SIGTERM
 
-
 DEBUG=${DEBUG:-false}
 TERMINATION_ENDPOINT="http://169.254.169.254/latest/meta-data/spot/termination-time"
 
+wget -O kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl && chmod +x ./kubectl
 
 echo "[$(date '+%Y-%m-%d %H:%M:%S')] INFO: Starting on node ${MY_NODE_NAME}"
 echo "[$(date '+%Y-%m-%d %H:%M:%S')] INFO: polling AWS meta-data every 5 seconds"
@@ -14,7 +14,7 @@ while true; do
   if [[ ${status_code} == "200" ]]; then
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] INFO: Initiating node drain. Received termination signal from AWS"
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] INFO: Draining ${MY_NODE_NAME}"
-    /app/kubectl drain "${MY_NODE_NAME}" --force --delete-local-data --grace-period=110 --ignore-daemonsets
+    ./kubectl drain "${MY_NODE_NAME}" --force --delete-local-data --grace-period=110 --ignore-daemonsets
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] INFO: Done"
     break
   else


### PR DESCRIPTION
This changes aim to make kubectl easier to update, instead of having to build a new image changing kubectl version, it is passed as an env variable and installed when the pod is up.

The only doubt I have is that the kubectl binary will be downloaded every time a pod is scaled, so it could delay the pod a bit and would increase our net usage. What do you think @phspagiari?